### PR TITLE
Tests: Update memory regex to support 48 bits addresses

### DIFF
--- a/dumper_test.go
+++ b/dumper_test.go
@@ -48,7 +48,7 @@ var DumpEquals Checker = &dumpEqualsChecker{
 	&CheckerInfo{Name: "DumpEquals", Params: []string{"obtained", "expected"}},
 }
 
-var memoryRegexp = regexp.MustCompile("0x[0-9a-f]{8,10}")
+var memoryRegexp = regexp.MustCompile("0x[0-9a-f]{8,12}")
 
 func (checker *dumpEqualsChecker) Check(params []interface{}, names []string) (result bool, error string) {
 	defer func() {


### PR DESCRIPTION
Fix the execution of tests in a local environment with M1. 
![image](https://github.com/symfony-cli/dumper/assets/2785399/69924611-a408-4d6e-b1ee-0d29cbda6ee7)
